### PR TITLE
Fix cluster label visibility on zoom

### DIFF
--- a/src/components/ClusterLabel/index.tsx
+++ b/src/components/ClusterLabel/index.tsx
@@ -1,35 +1,23 @@
 import { useFrame, useThree } from '@react-three/fiber'
 import { Html } from '@react-three/drei'
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import * as THREE from 'three'
 
 type ClusterLabelProps = {
   position: [number, number, number]
   text: string
   color: string
-  hideDistance?: number // optional threshold for hiding label
 }
 
-const ClusterLabel = ({
-  position,
-  text,
-  color,
-  hideDistance = 5
-}: ClusterLabelProps) => {
+const ClusterLabel = ({ position, text, color }: ClusterLabelProps) => {
   const groupRef = useRef<THREE.Group>(null)
   const { camera } = useThree()
-  const [visible, setVisible] = useState(true)
 
   useFrame(() => {
     if (!groupRef.current) return
-    // Calculate distance from camera to the label's position
-    const dist = camera.position.distanceTo(new THREE.Vector3(...position))
-    // Hide if camera is closer than hideDistance
-    setVisible(dist > hideDistance)
+    // Keep the label facing the camera for readability
+    groupRef.current.quaternion.copy(camera.quaternion)
   })
-
-  // If not visible, return null to hide the label
-  if (!visible) return null
 
   return (
     <group ref={groupRef} position={position}>

--- a/src/components/quran-visualization.tsx
+++ b/src/components/quran-visualization.tsx
@@ -128,15 +128,13 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
         />
       ))}
       
-      {/* Render cluster labels based on core meaning. 
-          Assume ClusterLabel hides itself when the camera is too close (using the hideDistance prop). */}
+      {/* Render cluster labels based on core meaning */}
       {Object.entries(clusterCentroids).map(([core, position]) => (
         <ClusterLabel
           key={`cluster-${core}`}
           position={position}
           text={core || 'Cluster'}
           color={colorScale(core)}
-          hideDistance={8} // Adjust threshold as needed.
         />
       ))}
       


### PR DESCRIPTION
## Summary
- make ClusterLabel always face the camera instead of hiding on zoom
- remove unused hideDistance prop from cluster labels

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn install --immutable --mode=skip-build` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6885e27f67bc8328beff592657e336ca