### PR TITLE
Improve cluster highlighting

### DIFF
--- a/src/components/ClusterLabel/index.tsx
+++ b/src/components/ClusterLabel/index.tsx
@@ -7,9 +7,11 @@ type ClusterLabelProps = {
   position: [number, number, number]
   text: string
   color: string
+  onClick?: () => void
+  active?: boolean
 }
 
-const ClusterLabel = ({ position, text, color }: ClusterLabelProps) => {
+const ClusterLabel = ({ position, text, color, onClick, active = false }: ClusterLabelProps) => {
   const groupRef = useRef<THREE.Group>(null)
   const { camera } = useThree()
 
@@ -20,9 +22,9 @@ const ClusterLabel = ({ position, text, color }: ClusterLabelProps) => {
   })
 
   return (
-    <group ref={groupRef} position={position}>
+    <group ref={groupRef} position={position} onClick={onClick}>
       {/* Optional colored sprite behind the text */}
-      <sprite scale={[1, 0.5, 1]} position={[0, 0.1, 0]}>
+      <sprite scale={active ? [1.2, 0.6, 1.2] : [1, 0.5, 1]} position={[0, 0.1, 0]}>
         <spriteMaterial transparent opacity={0.7} color={color} />
       </sprite>
       <Html distanceFactor={10}>
@@ -35,7 +37,8 @@ const ClusterLabel = ({ position, text, color }: ClusterLabelProps) => {
           whiteSpace: 'nowrap',
           userSelect: 'none',
           pointerEvents: 'none',
-          transform: 'translate3d(-50%, -50%, 0)'
+          transform: 'translate3d(-50%, -50%, 0)',
+          border: active ? '1px solid white' : undefined
         }}>
           {text}
         </div>

--- a/src/components/quran-visualization.tsx
+++ b/src/components/quran-visualization.tsx
@@ -14,32 +14,31 @@ type PointProps = {
   verse: VerseData
   onSelect: (verse: VerseData) => void
   isSelected: boolean
+  activeCluster: string | null
 }
 
 // Individual point component remains similar.
-const Point = ({ position, color, verse, onSelect, isSelected }: PointProps) => {
+const Point = ({ position, color, verse, onSelect, isSelected, activeCluster }: PointProps) => {
   const meshRef = useRef<THREE.Mesh>(null)
-  
+  const isHighlighted = activeCluster ? verse.core_meaning.trim() === activeCluster : false
+
   useFrame(() => {
     if (!meshRef.current) return
-    if (isSelected) {
-      meshRef.current.scale.x = THREE.MathUtils.lerp(meshRef.current.scale.x, 1.3, 0.1)
-      meshRef.current.scale.y = THREE.MathUtils.lerp(meshRef.current.scale.y, 1.3, 0.1)
-      meshRef.current.scale.z = THREE.MathUtils.lerp(meshRef.current.scale.z, 1.3, 0.1)
-    } else {
-      meshRef.current.scale.x = THREE.MathUtils.lerp(meshRef.current.scale.x, 1, 0.1)
-      meshRef.current.scale.y = THREE.MathUtils.lerp(meshRef.current.scale.y, 1, 0.1)
-      meshRef.current.scale.z = THREE.MathUtils.lerp(meshRef.current.scale.z, 1, 0.1)
-    }
+    const targetScale = isSelected || isHighlighted ? 1.3 : 1
+    meshRef.current.scale.x = THREE.MathUtils.lerp(meshRef.current.scale.x, targetScale, 0.1)
+    meshRef.current.scale.y = THREE.MathUtils.lerp(meshRef.current.scale.y, targetScale, 0.1)
+    meshRef.current.scale.z = THREE.MathUtils.lerp(meshRef.current.scale.z, targetScale, 0.1)
   })
   
   return (
     <mesh ref={meshRef} position={position} onClick={() => onSelect(verse)}>
       <sphereGeometry args={[0.015, 8, 8]} />
-      <meshStandardMaterial 
-        color={color} 
-        emissive={isSelected ? 'white' : color}
-        emissiveIntensity={isSelected ? 0.5 : 0}
+      <meshStandardMaterial
+        color={color}
+        transparent
+        opacity={activeCluster && !isHighlighted ? 0.2 : 1}
+        emissive={isSelected || isHighlighted ? 'white' : color}
+        emissiveIntensity={isSelected ? 0.5 : isHighlighted ? 0.3 : 0}
       />
     </mesh>
   )
@@ -52,6 +51,7 @@ type PointCloudProps = {
 
 const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
   const [selectedVerse, setSelectedVerse] = useState<VerseData | null>(null)
+  const [activeCluster, setActiveCluster] = useState<string | null>(null)
   
   // Compute normalized positions and compute groupings by core_meaning.
   const { normalizedData, colorScale, clusterCentroids } = useMemo(() => {
@@ -125,6 +125,7 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
           verse={verse}
           onSelect={handleSelectVerse}
           isSelected={selectedVerse?.id === verse.id}
+          activeCluster={activeCluster}
         />
       ))}
       
@@ -135,6 +136,8 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
           position={position}
           text={core || 'Cluster'}
           color={colorScale(core)}
+          onClick={() => setActiveCluster(c => (c === core ? null : core))}
+          active={activeCluster === core}
         />
       ))}
       


### PR DESCRIPTION
## Summary
- make `ClusterLabel` clickable and style active state
- highlight verses from the selected cluster in `QuranVisualization`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885e51cfffc83289a71fd434e50e4b5