### PR TITLE
Add cluster search UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import VerseDetails from '@/components/verse-details'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { InfoIcon, BookOpenIcon } from 'lucide-react'
 
 export type VerseData = {
@@ -43,7 +44,9 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [selectedVerse, setSelectedVerse] = useState<VerseData | null>(null)
   const [showInfo, setShowInfo] = useState(true)
-  
+  const [search, setSearch] = useState('')
+  const [focusCluster, setFocusCluster] = useState<string | null>(null)
+
   useEffect(() => {
     fetch('/quran_embeddings_5.json')
       .then(response => response.json())
@@ -56,19 +59,40 @@ export default function Home() {
         setLoading(false)
       })
   }, [])
+
+  function handleSearch(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!search.trim()) {
+      setFocusCluster(null)
+      return
+    }
+    const entry = Object.values(data.clusters).find(c =>
+      c.core_meaning.toLowerCase().includes(search.toLowerCase())
+    )
+    setFocusCluster(entry ? entry.core_meaning.trim() : null)
+  }
   return (
     <main className="flex min-h-screen flex-col bg-background">
       <div className="container mx-auto p-4">
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
-          <div>
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 gap-4">
+          <div className="flex-1">
             <h1 className="text-3xl font-bold">Quran Verses in Semantic Space</h1>
             <p className="text-muted-foreground mt-2">
-              Explore the semantic relationships between Quran verses. 
+              Explore the semantic relationships between Quran verses.
               Similar colors indicate similar meanings.
             </p>
           </div>
-          <Button 
-            variant="outline" 
+          <form onSubmit={handleSearch} className="flex gap-2 items-center">
+            <Input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search theme..."
+              className="w-40"
+            />
+            <Button type="submit" variant="outline">Search</Button>
+          </form>
+          <Button
+            variant="outline"
             className="mt-2 sm:mt-0"
             onClick={() => setShowInfo(!showInfo)}
           >
@@ -76,6 +100,10 @@ export default function Home() {
             {showInfo ? "Hide Info" : "Show Info"}
           </Button>
         </div>
+
+        {focusCluster && (
+          <p className="mb-4 text-sm text-muted-foreground">Focusing on: {focusCluster}</p>
+        )}
         
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
           <div className={`${showInfo ? 'lg:col-span-3' : 'lg:col-span-4'} h-[700px] bg-muted rounded-lg overflow-hidden relative`}>
@@ -84,9 +112,10 @@ export default function Home() {
                 <Skeleton className="h-[600px] w-full" />
               </div>
             ) : (
-              <QuranVisualization 
-                data={data.points} 
-                onSelectVerse={setSelectedVerse} 
+              <QuranVisualization
+                data={data.points}
+                onSelectVerse={setSelectedVerse}
+                focusCluster={focusCluster}
               />
             )}
             

--- a/src/components/quran-visualization.tsx
+++ b/src/components/quran-visualization.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState, useMemo } from 'react'
+import { useRef, useState, useMemo, useEffect } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
@@ -50,11 +50,18 @@ const Point = ({ position, color, verse, onSelect, isSelected, activeCluster }: 
 type PointCloudProps = {
   data: VerseData[]
   onSelectVerse: (verse: VerseData) => void
+  focusCluster?: string | null
 }
 
-const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
+const QuranVisualization = ({ data, onSelectVerse, focusCluster }: PointCloudProps) => {
   const [selectedVerse, setSelectedVerse] = useState<VerseData | null>(null)
   const [activeCluster, setActiveCluster] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (focusCluster !== undefined) {
+      setActiveCluster(focusCluster)
+    }
+  }, [focusCluster])
   
   // Compute normalized positions and compute groupings by core_meaning.
   const { normalizedData, colorScale, clusterCentroids } = useMemo(() => {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = 'Input'
+
+export { Input }


### PR DESCRIPTION
## Summary
- add generic `Input` component
- support external cluster focus in the visualization
- add search box to focus on clusters by their core meaning

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688605c2457883288aec9b918552696a