### PR TITLE
Add honeycomb cluster layout and enhance ClusterLabel visuals/interactivity

### DIFF
--- a/src/components/ClusterLabel/index.tsx
+++ b/src/components/ClusterLabel/index.tsx
@@ -7,40 +7,42 @@ type ClusterLabelProps = {
   position: [number, number, number]
   text: string
   color: string
+  subtitle?: string
   onClick?: () => void
   active?: boolean
 }
 
-const ClusterLabel = ({ position, text, color, onClick, active = false }: ClusterLabelProps) => {
+const ClusterLabel = ({ position, text, color, subtitle, onClick, active = false }: ClusterLabelProps) => {
   const groupRef = useRef<THREE.Group>(null)
   const { camera } = useThree()
 
   useFrame(() => {
     if (!groupRef.current) return
-    // Keep the label facing the camera for readability
     groupRef.current.quaternion.copy(camera.quaternion)
   })
 
   return (
     <group ref={groupRef} position={position} onClick={onClick}>
-      {/* Optional colored sprite behind the text */}
-      <sprite scale={active ? [1.2, 0.6, 1.2] : [1, 0.5, 1]} position={[0, 0.1, 0]}>
-        <spriteMaterial transparent opacity={0.7} color={color} />
+      <sprite scale={active ? [2.1, 1.2, 1.6] : [1.8, 1, 1.4]} position={[0, 0.1, 0]}>
+        <spriteMaterial transparent opacity={active ? 0.9 : 0.75} color={color} />
       </sprite>
-      <Html distanceFactor={10}>
+      <Html distanceFactor={9}>
         <div style={{
           background: 'rgba(0,0,0,0.8)',
           color: 'white',
-          padding: '2px 6px',
-          borderRadius: '4px',
+          padding: '6px 10px',
+          borderRadius: '8px',
           fontSize: '12px',
+          lineHeight: 1.2,
           whiteSpace: 'nowrap',
           userSelect: 'none',
           pointerEvents: 'none',
           transform: 'translate3d(-50%, -50%, 0)',
-          border: active ? '1px solid white' : undefined
+          border: active ? '1px solid white' : undefined,
+          textAlign: 'center'
         }}>
-          {text}
+          <div style={{ fontWeight: 600 }}>{text}</div>
+          {subtitle ? <div style={{ opacity: 0.8, fontSize: '10px', marginTop: 2 }}>{subtitle}</div> : null}
         </div>
       </Html>
     </group>

--- a/src/components/quran-visualization.tsx
+++ b/src/components/quran-visualization.tsx
@@ -17,7 +17,6 @@ type PointProps = {
   activeCluster: string | null
 }
 
-// Individual point component remains similar.
 const Point = ({ position, color, verse, onSelect, isSelected, activeCluster }: PointProps) => {
   const meshRef = useRef<THREE.Mesh>(null)
   const isHighlighted = activeCluster ? verse.core_meaning.trim() === activeCluster : false
@@ -31,17 +30,15 @@ const Point = ({ position, color, verse, onSelect, isSelected, activeCluster }: 
     meshRef.current.scale.z = THREE.MathUtils.lerp(meshRef.current.scale.z, targetScale, 0.1)
   })
 
-  const baseSize = activeCluster ? 0.02 : 0.015
-
-  if (activeCluster && !isHighlighted) return null
+  const baseSize = activeCluster ? 0.02 : 0.012
 
   return (
     <mesh ref={meshRef} position={position} onClick={() => onSelect(verse)}>
-      <sphereGeometry args={[baseSize, 12, 12]} />
+      <sphereGeometry args={[baseSize, 10, 10]} />
       <meshStandardMaterial
         color={color}
         emissive={isSelected || isHighlighted ? 'white' : color}
-        emissiveIntensity={isSelected ? 0.5 : isHighlighted ? 0.3 : 0}
+        emissiveIntensity={isSelected ? 0.5 : isHighlighted ? 0.3 : 0.08}
       />
     </mesh>
   )
@@ -55,18 +52,20 @@ type PointCloudProps = {
 const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
   const [selectedVerse, setSelectedVerse] = useState<VerseData | null>(null)
   const [activeCluster, setActiveCluster] = useState<string | null>(null)
-  
-  // Compute normalized positions and compute groupings by core_meaning.
-  const { normalizedData, colorScale, clusterCentroids } = useMemo(() => {
-    if (!data.length) return { 
-      normalizedData: [], 
-      colorScale: () => '#ffffff',
-      clusterCentroids: {}
+
+  const { normalizedData, colorScale, clusterCentroids, clusterHexMap, uniqueCores } = useMemo(() => {
+    if (!data.length) {
+      return {
+        normalizedData: [],
+        colorScale: () => '#ffffff',
+        clusterCentroids: {},
+        clusterHexMap: {},
+        uniqueCores: [],
+      }
     }
-    
-    // Compute bounds for normalization.
-    let minX = Infinity, minY = Infinity, minZ = Infinity
-    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity
+
+    let minX = Infinity; let minY = Infinity; let minZ = Infinity
+    let maxX = -Infinity; let maxY = -Infinity; let maxZ = -Infinity
     data.forEach(point => {
       minX = Math.min(minX, point.x)
       minY = Math.min(minY, point.y)
@@ -75,7 +74,7 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
       maxY = Math.max(maxY, point.y)
       maxZ = Math.max(maxZ, point.z)
     })
-    
+
     const spreadFactor = 4
     const normalizedData = data.map(point => ({
       ...point,
@@ -83,47 +82,66 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
       normalizedY: ((point.y - minY) / (maxY - minY) * 2 - 1) * spreadFactor,
       normalizedZ: ((point.z - minZ) / (maxZ - minZ) * 2 - 1) * spreadFactor,
     }))
-    
-    // Create a color scale based on unique core_meaning strings.
+
     const uniqueCores = Array.from(new Set(normalizedData.map(p => p.core_meaning.trim()))).sort()
     const numCores = uniqueCores.length
     const colorScale = (core: string) => {
       const index = uniqueCores.indexOf(core.trim())
       if (index === -1 || numCores === 1) return '#ffffff'
-      const normalizedValue = index / (numCores - 1)
-      return interpolateRainbow(normalizedValue)
+      return interpolateRainbow(index / (numCores - 1))
     }
-    
-    // Compute cluster centroids by grouping points with the same core meaning.
+
     const clusterCentroids: Record<string, [number, number, number]> = {}
     uniqueCores.forEach(core => {
       const clusterPoints = normalizedData.filter(p => p.core_meaning.trim() === core)
-      if (clusterPoints.length > 0) {
-        const avgX = clusterPoints.reduce((sum, p) => sum + p.normalizedX, 0) / clusterPoints.length
-        const avgY = clusterPoints.reduce((sum, p) => sum + p.normalizedY, 0) / clusterPoints.length
-        const avgZ = clusterPoints.reduce((sum, p) => sum + p.normalizedZ, 0) / clusterPoints.length
-        clusterCentroids[core] = [avgX, avgY, avgZ]
+      if (!clusterPoints.length) return
+      const avgX = clusterPoints.reduce((sum, p) => sum + p.normalizedX, 0) / clusterPoints.length
+      const avgY = clusterPoints.reduce((sum, p) => sum + p.normalizedY, 0) / clusterPoints.length
+      const avgZ = clusterPoints.reduce((sum, p) => sum + p.normalizedZ, 0) / clusterPoints.length
+      clusterCentroids[core] = [avgX, avgY, avgZ]
+    })
+
+    const clusterHexMap: Record<string, [number, number, number]> = {}
+    const columns = Math.ceil(Math.sqrt(uniqueCores.length))
+    const hexRadius = 1.4
+    uniqueCores.forEach((core, index) => {
+      const col = index % columns
+      const row = Math.floor(index / columns)
+      const x = (col - columns / 2) * (hexRadius * 1.75) + (row % 2 === 0 ? 0 : hexRadius * 0.85)
+      const y = (Math.ceil(uniqueCores.length / columns) / 2 - row) * (hexRadius * 1.5)
+      clusterHexMap[core] = [x, y, 0]
+    })
+
+    return { normalizedData, colorScale, clusterCentroids, clusterHexMap, uniqueCores }
+  }, [data])
+
+  const displayedData = useMemo(() => {
+    return normalizedData.map(verse => {
+      const core = verse.core_meaning.trim()
+      if (activeCluster) {
+        return verse
+      }
+      const hex = clusterHexMap[core] ?? [0, 0, 0]
+      return {
+        ...verse,
+        normalizedX: hex[0] + verse.normalizedX * 0.09,
+        normalizedY: hex[1] + verse.normalizedY * 0.09,
+        normalizedZ: verse.normalizedZ * 0.03,
       }
     })
-    
-    return { normalizedData, colorScale, clusterCentroids }
-  }, [data])
-  
+  }, [normalizedData, activeCluster, clusterHexMap])
+
   const handleSelectVerse = (verse: VerseData) => {
     setSelectedVerse(verse)
     onSelectVerse(verse)
   }
-  
+
   return (
-    <Canvas camera={{ position: [0, 0, 10], fov: 50 }}>
-      <ambientLight intensity={0.5} />
+    <Canvas camera={{ position: [0, 0, 12], fov: 50 }}>
+      <ambientLight intensity={0.55} />
       <pointLight position={[10, 10, 10]} intensity={1} />
-      
-      {/* Render individual points */}
-      {(activeCluster ?
-        normalizedData.filter(v => v.core_meaning.trim() === activeCluster) :
-        normalizedData
-      ).map((verse, index) => (
+
+      {(activeCluster ? displayedData.filter(v => v.core_meaning.trim() === activeCluster) : displayedData).map((verse, index) => (
         <Point
           key={`verse-${verse.surah_id}-${verse.ayah}-${index}`}
           position={[verse.normalizedX, verse.normalizedY, verse.normalizedZ]}
@@ -134,31 +152,21 @@ const QuranVisualization = ({ data, onSelectVerse }: PointCloudProps) => {
           activeCluster={activeCluster}
         />
       ))}
-      
-      {/* Render cluster labels based on core meaning */}
-      {(activeCluster ?
-        Object.entries(clusterCentroids).filter(([core]) => core === activeCluster) :
-        Object.entries(clusterCentroids)
-      ).map(([core, position]) => (
+
+      {(activeCluster ? [activeCluster] : uniqueCores).map((core) => (
         <ClusterLabel
           key={`cluster-${core}`}
-          position={position}
+          position={activeCluster ? clusterCentroids[core] : clusterHexMap[core]}
           text={core || 'Cluster'}
           color={colorScale(core)}
+          subtitle={activeCluster ? 'Click to return to honeycomb' : 'Click to focus'}
           onClick={() => setActiveCluster(c => (c === core ? null : core))}
           active={activeCluster === core}
         />
       ))}
-      
-      <OrbitControls 
-        enableDamping 
-        dampingFactor={0.05} 
-        rotateSpeed={0.5}
-        zoomSpeed={0.7}
-        maxDistance={20}
-      />
-      
-      <gridHelper args={[10, 20]} position={[0, -5, 0]} />
+
+      <OrbitControls enableDamping dampingFactor={0.05} rotateSpeed={0.45} zoomSpeed={0.7} maxDistance={24} />
+      <gridHelper args={[16, 24]} position={[0, -6, 0]} />
     </Canvas>
   )
 }


### PR DESCRIPTION
### Motivation

- Improve cluster readability and visual hierarchy by introducing a honeycomb layout for clusters and clearer labels.
- Provide better focus/selection feedback and make cluster labels more informative with an optional subtitle.
- Tweak rendering parameters to improve visual clarity and interaction responsiveness.

### Description

- Extended `ClusterLabel` to accept an optional `subtitle` prop and updated visuals: larger sprite scale, increased opacity when active, rounded padding/border radius, centered text, and subtitle rendering; the label still faces the camera via the group quaternion copy.
- Added a honeycomb layout generation in `quran-visualization.tsx` by computing `clusterHexMap`, `uniqueCores`, and `clusterCentroids`, and introduced `displayedData` which places verses into hex buckets when no cluster is active while preserving detailed positions when focused.
- Adjusted `Point` rendering: changed base radius calculation, reduced sphere segment count, and tuned `emissiveIntensity` for subtle glow on selection/highlight; removed the early-return hiding behavior so points are always considered and positioned by the honeycomb logic.
- Updated scene parameters: camera position changed to `[0, 0, 12]`, ambient light intensity increased, `OrbitControls` and `gridHelper` parameters adjusted, and cluster labels now use hex positions when not focused and cluster centroids when focused; clicking a label toggles focus and shows a contextual subtitle.

### Testing

- Ran TypeScript type check with `tsc --noEmit` which succeeded.
- Ran linter checks with `eslint .` which reported no errors.
- Performed a local production build (`npm run build`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87e8905148328ad0ea3a97a8d23ba)